### PR TITLE
Add _getline and remove left tabs

### DIFF
--- a/_getline.c
+++ b/_getline.c
@@ -1,0 +1,61 @@
+#include "main.h"
+
+/**
+ * _getline - init data
+ * @d: data struct input
+ * @shell_name: string input
+ * Return: void
+ */
+ssize_t _getline(char **lineptr, size_t *n, FILE *stream)
+{
+	ssize_t bytesRead = 0;
+	size_t position = 0;
+	static char buf[READ_BUF_SIZE];
+	static size_t bufSize = 0;
+	static size_t bufPos = 0;
+
+	if (lineptr == NULL || n == NULL || stream == NULL)
+		return -1;
+	if (*lineptr == NULL || *n == 0)
+	{
+		*n = 128;
+		*lineptr = malloc(*n);
+		if (*lineptr == NULL)
+			return -1;
+	}
+
+	while (1) {
+			if (bufPos >= bufSize) {
+				bytesRead = read(fileno(stream), buf, READ_BUF_SIZE);
+				if (bytesRead <= 0) {
+					if (position == 0) {
+						return -1; 
+					} else {
+						break;
+					}
+				}
+				bufSize = bytesRead;
+				bufPos = 0;
+			}
+
+			
+			if (position >= *n - 1) {
+				size_t newSize = *n * 2;
+				char *newBuffer = realloc(*lineptr, newSize);
+				if (newBuffer == NULL) {
+					return -1;
+				}
+				*lineptr = newBuffer;
+				*n = newSize;
+			}
+
+			(*lineptr)[position++] = buf[bufPos++];
+			if ((*lineptr)[position - 1] == '\n') {
+				break;
+			}
+		}
+
+    (*lineptr)[position] = '\0';
+
+    return (position);
+}

--- a/_getline.c
+++ b/_getline.c
@@ -26,7 +26,7 @@ ssize_t _getline(char **lineptr, size_t *n, FILE *stream)
 
 	while (1) {
 			if (bufPos >= bufSize) {
-				bytesRead = read(fileno(stream), buf, READ_BUF_SIZE);
+				bytesRead = read(stream->_fileno, buf, READ_BUF_SIZE);
 				if (bytesRead <= 0) {
 					if (position == 0) {
 						return -1; 

--- a/_getline.c
+++ b/_getline.c
@@ -1,61 +1,66 @@
 #include "main.h"
 
 /**
- * _getline - init data
- * @d: data struct input
- * @shell_name: string input
- * Return: void
+ * _getline_helper - getline helper function
+ * @lineptr: string input
+ * @n: int input
+ * Return: int
  */
-ssize_t _getline(char **lineptr, size_t *n, FILE *stream)
+int _getline_helper(char **lineptr, size_t *n)
 {
-	ssize_t bytesRead = 0;
-	size_t position = 0;
-	static char buf[READ_BUF_SIZE];
-	static size_t bufSize = 0;
-	static size_t bufPos = 0;
-
-	if (lineptr == NULL || n == NULL || stream == NULL)
-		return -1;
 	if (*lineptr == NULL || *n == 0)
 	{
 		*n = 128;
 		*lineptr = malloc(*n);
 		if (*lineptr == NULL)
-			return -1;
+			return (-1);
 	}
+	return (0);
+}
 
-	while (1) {
-			if (bufPos >= bufSize) {
-				bytesRead = read(stream->_fileno, buf, READ_BUF_SIZE);
-				if (bytesRead <= 0) {
-					if (position == 0) {
-						return -1; 
-					} else {
-						break;
-					}
-				}
-				bufSize = bytesRead;
-				bufPos = 0;
-			}
+/**
+ * _getline - reads the input from FILE
+ * @lineptr: string input
+ * @n: int input
+ * @stream: FILE input
+ * Return: ssize_t
+ */
+ssize_t _getline(char **lineptr, size_t *n, FILE *stream)
+{
+	ssize_t bytesRead = 0;
+	size_t position = 0, newSize;
+	static char buf[READ_BUF_SIZE];
+	static size_t bufSize, bufPos;
+	char *newBuffer;
 
-			
-			if (position >= *n - 1) {
-				size_t newSize = *n * 2;
-				char *newBuffer = realloc(*lineptr, newSize);
-				if (newBuffer == NULL) {
-					return -1;
-				}
-				*lineptr = newBuffer;
-				*n = newSize;
-			}
-
-			(*lineptr)[position++] = buf[bufPos++];
-			if ((*lineptr)[position - 1] == '\n') {
+	if (lineptr == NULL || n == NULL || stream == NULL
+		|| _getline_helper(lineptr, n) == -1)
+		return (-1);
+	while (1)
+	{
+		if (bufPos >= bufSize)
+		{
+			bytesRead = read(stream->_fileno, buf, READ_BUF_SIZE);
+			if (bytesRead <= 0 && position == 0)
+				return (-1);
+			else if (bytesRead <= 0)
 				break;
-			}
+			bufSize = bytesRead;
+			bufPos = 0;
 		}
-
-    (*lineptr)[position] = '\0';
-
-    return (position);
+		if (position >= *n - 1)
+		{
+			newSize = *n * 2;
+			newBuffer = realloc(*lineptr, newSize);
+			if (newBuffer == NULL)
+				return (-1);
+			*lineptr = newBuffer;
+			*n = newSize;
+		}
+		(*lineptr)[position++] = buf[bufPos++];
+		if ((*lineptr)[position - 1] == '\n')
+			break;
+	}
+	(*lineptr)[position] = '\0';
+	return (position);
 }

--- a/exec.c
+++ b/exec.c
@@ -56,19 +56,20 @@ void _exec(data *d)
 		_printf(prompt);
 
 		read_cmd(d);
-
-		split(d, " ");
-
-		if (!exec_builtin(d))
+		if (_strlen(d->cmd) != 0)
 		{
-			_which(d);
-			if (access(d->av[0], F_OK) == -1)
+			split(d, " ");
+			if (!exec_builtin(d))
 			{
-				perror(d->shell_name);
-			}
-			else
-			{
-				start_process(d);
+				_which(d);
+				if (access(d->av[0], F_OK) == -1)
+				{
+					perror(d->shell_name);
+				}
+				else
+				{
+					start_process(d);
+				}
 			}
 		}
 		free_array(d->av);

--- a/helpers.c
+++ b/helpers.c
@@ -112,5 +112,5 @@ void read_cmd(data *d)
 	}
 
 	d->cmd[nread - 1] = '\0';
-	remove_left_spaces(d->cmd);
+	_trim(d->cmd);
 }

--- a/helpers.c
+++ b/helpers.c
@@ -103,7 +103,7 @@ void read_cmd(data *d)
 	size_t n = 0;
 	ssize_t nread;
 
-	nread = getline(&d->cmd, &n, stdin);
+	nread = _getline(&d->cmd, &n, stdin);
 
 	if (nread == -1)
 	{

--- a/helpers2.c
+++ b/helpers2.c
@@ -38,7 +38,7 @@ void remove_left_spaces(char *str)
 {
 	int i, j, len = _strlen(str);
 
-	for (i = 0; i < len && str[i] == ' '; i++)
+	for (i = 0; i < len && (str[i] == ' ' || str[i] == '\t'); i++)
 		;
 	for (j = 0; i < len ; i++, j++)
 	{

--- a/helpers2.c
+++ b/helpers2.c
@@ -29,22 +29,25 @@ void _perror(const char *str1, const char *str2)
 
 
 /**
- * remove_left_spaces - remove leading spaces from a character string
+ * _trim - remove leading and trailing spaces and tabs from a string
  * @str: string input
  * Return: void.
  */
 
-void remove_left_spaces(char *str)
+void _trim(char *str)
 {
 	int i, j, len = _strlen(str);
 
 	for (i = 0; i < len && (str[i] == ' ' || str[i] == '\t'); i++)
 		;
+
 	for (j = 0; i < len ; i++, j++)
-	{
 		str[j] = str[i];
-	}
+
 	str[j] = '\0';
+
+	for (i = _strlen(str) - 1; i > 0 && (str[i] == ' ' || str[i] == '\t'); i--)
+		str[i] = '\0';
 }
 
 

--- a/main.h
+++ b/main.h
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <sys/wait.h>
 #include <errno.h>
 #include <string.h>
@@ -70,5 +71,11 @@ char *_strcat(char *dest, const char *src);
 
 /* string_utils2.c */
 char *_strdup(const char *str);
+
+/* _getline.c */
+#define READ_BUF_SIZE 1024
+
+ssize_t _getline(char **lineptr, size_t *n, FILE *stream);
+
 
 #endif

--- a/main.h
+++ b/main.h
@@ -50,7 +50,7 @@ void read_cmd(data *d);
 
 /* helpers2.c */
 void _perror(const char *str1, const char *str2);
-void remove_left_spaces(char *str);
+void _trim(char *str);
 void *_realloc(void *ptr, unsigned int new_size);
 
 /* exec.c */


### PR DESCRIPTION
Add _getline
remove left tabs
Fix - _exec if the cmd is only spaces
Refactoring remove_left_spaces to _trim which removes leading and trailing spaces and tabs from a string